### PR TITLE
feat: redirect Buy Now button to app registration page

### DIFF
--- a/src/page-components/BecomeMember/Pricing.jsx
+++ b/src/page-components/BecomeMember/Pricing.jsx
@@ -373,17 +373,15 @@ export default function Pricing() {
                    
                     </div>
                     )}
-                    <button
-                      onClick={openModal}
+                    <a
+                      href={`https://app.bnglogisticsnetwork.com/register?plan=${tier.name.toLowerCase()}`}
                       className={classNames(
-                        tier.id === 'tier-Free' 
-                          ? 'bg-gradient-to-tr from-[#6853DB] to-[#6853DB] hover:from-[#5844B4] hover:to-[#5844B4] text-white' 
-                          : 'bg-gradient-to-tr from-[#6853DB] to-[#6853DB] hover:from-[#5844B4] hover:to-[#5844B4] text-white',
+                        'bg-gradient-to-tr from-[#6853DB] to-[#6853DB] hover:from-[#5844B4] hover:to-[#5844B4] text-white',
                         'mt-4 block rounded-md hover:scale-105 px-4 py-3 text-center text-base font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 w-full transition-transform duration-200'
                       )}
                     >
-                      {tier.id === 'tier-Free' ? 'Start Free Trial' : 'Buy Now'}
-                    </button>
+                      Buy Now
+                    </a>
                   </div>
                   {/* Features */}
                   <div className="mt-6 space-y-4">
@@ -543,19 +541,17 @@ export default function Pricing() {
                     
                       </div>
                       )}
-                      <button
-                        onClick={openModal}
+                      <a
+                        href={`https://app.bnglogisticsnetwork.com/register?plan=${tier.name.toLowerCase()}`}
                         className={classNames(
-                          tier.id === 'tier-Free' 
-                            ? 'bg-gradient-to-tr from-[#6853DB] to-[#6853DB] text-white hover:bg-gradient-to-tr hover:from-[#5844B4] hover:to-[#5844B4]' 
-                            : tier.mostPopular
-                              ? 'bg-gradient-to-tr from-[#6853DB] to-[#6853DB] text-white hover:bg-gradient-to-tr hover:from-[#5844B4] hover:to-[#5844B4]'
-                              : 'text-[#6853DB] ring-1 ring-inset ring-[#6853DB]/20 hover:ring-[#6853DB]/30',
+                          tier.mostPopular
+                            ? 'bg-gradient-to-tr from-[#6853DB] to-[#6853DB] text-white hover:bg-gradient-to-tr hover:from-[#5844B4] hover:to-[#5844B4]'
+                            : 'text-[#6853DB] ring-1 ring-inset ring-[#6853DB]/20 hover:ring-[#6853DB]/30',
                           'mt-6 block rounded-md hover:scale-105 px-4 py-3 text-center text-base font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 w-full transition-transform duration-200'
                         )}
                       >
-                        {tier.id === 'tier-Free' ? 'Start Free Trial' : 'Buy Now'}
-                      </button>
+                        Buy Now
+                      </a>
                     </td>
                   ))}
                 </tr>


### PR DESCRIPTION
## Summary

- Replace the `onClick={openModal}` handler on the Buy Now button (both mobile and desktop views in Pricing.jsx) with a direct `<a>` link to `https://app.bnglogisticsnetwork.com/register?plan=<planname>`
- Passes the plan name (`standard`, `premium`, `elite`) as a query param so the registration page can pre-select the correct plan
- Removes the modal popup on Buy Now click

## Test plan

- [ ] Click Buy Now on Standard — redirects to app.bnglogisticsnetwork.com/register?plan=standard
- [ ] Click Buy Now on Premium — redirects with ?plan=premium
- [ ] Click Buy Now on Elite — redirects with ?plan=elite
- [ ] Verify modal no longer opens on Buy Now click